### PR TITLE
Support l10n style

### DIFF
--- a/src/frameworks/flutter-l10n.ts
+++ b/src/frameworks/flutter-l10n.ts
@@ -34,6 +34,7 @@ class FlutterL10nFramework extends Framework {
   usageMatchRegex = [
     '(?<annotation>S\\.of\\([\\w.]+\\)[?!]?\\.(?<key>{key}))\\W',
     '(?<annotation>AppLocalizations\\.of\\([\\w.]+\\)[?!]?\\.(?<key>{key}))\\W',
+    '(?<annotation>l10n\\.(?<key>{key}))\\W',
   ]
 
   preferredKeystyle?: KeyStyle = 'flat'
@@ -44,6 +45,7 @@ class FlutterL10nFramework extends Framework {
     return [
       `S.of(context).${keypath}`,
       `AppLocalizations.of(context).${keypath}`,
+      `l10n.${keypath}`,
       keypath,
     ]
   }


### PR DESCRIPTION
Hi @ipcjs! First of all, I want to say thank you so so much for making your fork of `i18n-ally`. It seems like none of the big localization plugins support the new Flutter `gen-l10n` style of localization, so your work is greatly appreciated!

I work on the [Thunder for Lemmy](https://github.com/thunder-app/thunder) mobile app project, and I wanted to propose an addition to your plugin based on how our team uses localizations. It's a small enhancement, but it would make our workflow much easier, and I don't think it would negatively affect people not using this style.

Rather than using the full `AppLocalizations.of(context).myString` everywhere we need to reference a string, which can make the code overly verbose and bloated, we define one instance of the localizations class (usually at the beginning of the `build` method) and subsequently reference that instance. It looks like this.

``` dart
@override
Widget build(BuildContext context) {
  final AppLocalizations l10n = AppLocalizations.of(context)!;
  return Text(l10n.myString);
}
```

Obviously it doesn't make a huge difference in this small example, but you can see how the terseness of the reference would make the code overall much cleaner.

This PR adds support for that syntax. Obviously it would require that the `l10n` instance already exists, but once it does, the string replacement should fit right into our program. It should also allow the annotations to work with our code.

I'd be interested to hear if you'd be open to adding this change!